### PR TITLE
Fix a couple bugs for a working dev version

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -79,7 +79,7 @@
         <script src="/cdn/bower_components/angular/angular.js"></script>
         <script src="/cdn/bower_components/angular-resource/angular-resource.js"></script>
         <script src="/cdn/bower_components/angular-route/angular-route.js"></script>
-        <script src="/cdn/bower_components/angular-local-storage/angular-local-storage.js"></script>
+        <script src="/cdn/bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
 
 
         <script src="/cdn/scripts/app.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "angular": "~1.2.5",
     "angular-route": "~1.2.5",
     "bootstrap": "~3.0.3",
-    "angular-local-storage": "*"
+    "angular-local-storage": "*",
+    "angular-resource": "*"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Needed to add `angular-resource` to bower and revise the location of `angular-local-storage` because they changed the organization of their repo.

For long-term stability it'd probably help to pin the versions of `angular-resource` and `angular-local-storage` in `bower.json` but, meh, I'm just using this today to try out print.io

Thanks for the demo repo!
